### PR TITLE
recurrence: add recurring task support with ghost event preview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,14 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- Recurring task support: add a `[recurrence:: <pattern>]` inline property or
+  `recurrence` frontmatter field to a task, and completing it will automatically
+  create the next occurrence with an updated due date. Supported patterns
+  include `every day`, `every N days/weeks/months/years`, `every weekday`, and
+  `every monday`..`every sunday`.
+
 ## [0.1.2]
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -9,24 +9,29 @@ easy-to-manage interface.
 
 ## Supported task formats
 
-- Supports tasks defined with basic dates:
+- Tasks with a due date:
   ```
   - [ ] Task description [due:: YYYY-MM-DD]
   ```
-- Supports multi-day tasks:
+- Multi-day tasks:
   ```
   - [ ] Task description [start:: YYYY-MM-DD] [due:: YYYY-MM-DD]
   ```
-- Supports tasks with specific date and time:
+- Tasks with a specific time:
   ```
   - [ ] Task description [due:: YYYY-MM-DDTHH:mm]
   ```
-- Supports file property tasks (using frontmatter):
+- Recurring tasks:
+  ```
+  - [ ] Weekly review [due:: 2026-03-01] [recurrence:: every week]
+  ```
+- File property tasks (using frontmatter):
   ```yaml
   ---
   due: YYYY-MM-DD
-  start: YYYY-MM-DD # Optional for multi-day tasks
-  status: ' ' # optional, empty string means this task is "Incomplete"
+  start: YYYY-MM-DD # optional, for multi-day tasks
+  status: ' ' # optional, empty means "Incomplete"
+  recurrence: every week # optional
   ---
   ```
   The file name becomes the task title, and the entire note becomes a task.
@@ -147,6 +152,24 @@ You can install Tasks Calendar either via
 - **File property tasks** Add status and date properties to your frontmatter to
   treat entire notes as tasks. The file name will display as the task title on
   the calendar.
+
+- **Recurring tasks** Add a `[recurrence:: <pattern>]` property to any task.
+  When the task is marked as completed, a new incomplete task is automatically
+  created with the next due date. The original task stays completed, and the new
+  task appears on the calendar at the next occurrence.
+
+  Supported patterns:
+  - `every day`, `every N days`
+  - `every week`, `every N weeks`
+  - `every month`, `every N months`
+  - `every year`, `every N years`
+  - `every weekday` (Monday through Friday)
+  - `every monday`, `every tuesday`, ..., `every sunday`
+
+  For inline tasks, the new task is inserted on the line immediately after the
+  completed task. For file property tasks, the completed file is renamed to
+  `<name> (completed <date>).md` and a new file with the original name is
+  created with the updated due date.
 
 ## Related plugins
 

--- a/src/backend/recurrence.ts
+++ b/src/backend/recurrence.ts
@@ -1,0 +1,184 @@
+import { DateTime, type WeekdayNumbers } from 'luxon';
+import {
+  ParsedTask,
+  cloneTask,
+  getTaskProperty,
+  setTaskProperty,
+  removeTaskProperty,
+  reconstructTask,
+} from './parse';
+
+export interface RecurrenceRule {
+  interval: number;
+  unit: 'day' | 'week' | 'month' | 'year';
+  weekday?: number; // 1=Monday .. 7=Sunday (ISO weekday)
+}
+
+const WEEKDAY_NAMES: Record<string, number> = {
+  monday: 1,
+  tuesday: 2,
+  wednesday: 3,
+  thursday: 4,
+  friday: 5,
+  saturday: 6,
+  sunday: 7,
+};
+
+export function parseRecurrence(pattern: string): RecurrenceRule | null {
+  const normalized = pattern.trim().toLowerCase();
+
+  if (normalized === 'every day') return { interval: 1, unit: 'day' };
+  if (normalized === 'every week') return { interval: 1, unit: 'week' };
+  if (normalized === 'every month') return { interval: 1, unit: 'month' };
+  if (normalized === 'every year') return { interval: 1, unit: 'year' };
+
+  if (normalized === 'every weekday') {
+    return { interval: 1, unit: 'day', weekday: -1 };
+  }
+
+  const weekdayMatch = normalized.match(/^every (\w+)$/);
+  if (weekdayMatch && WEEKDAY_NAMES[weekdayMatch[1]] !== undefined) {
+    return {
+      interval: 1,
+      unit: 'week',
+      weekday: WEEKDAY_NAMES[weekdayMatch[1]],
+    };
+  }
+
+  const intervalMatch = normalized.match(
+    /^every (\d+) (days?|weeks?|months?|years?)$/
+  );
+  if (intervalMatch) {
+    const interval = parseInt(intervalMatch[1]);
+    const rawUnit = intervalMatch[2].replace(/s$/, '');
+    const unit = rawUnit as RecurrenceRule['unit'];
+    return { interval, unit };
+  }
+
+  return null;
+}
+
+export function calculateNextDate(
+  currentDate: string,
+  rule: RecurrenceRule
+): string {
+  const hasTime = currentDate.includes('T');
+  const dt = DateTime.fromISO(currentDate);
+  if (!dt.isValid) return currentDate;
+
+  let next: DateTime;
+
+  if (rule.weekday === -1) {
+    // "every weekday": advance to the next weekday (Mon-Fri)
+    next = dt.plus({ days: 1 });
+    while (next.weekday > 5) {
+      next = next.plus({ days: 1 });
+    }
+  } else if (rule.weekday !== undefined && rule.unit === 'week') {
+    // "every monday", etc.: advance to the next occurrence of that weekday
+    next = dt.plus({ weeks: rule.interval });
+    next = next.set({ weekday: rule.weekday as WeekdayNumbers });
+    // Ensure it's strictly after the current date
+    if (next <= dt) {
+      next = next.plus({ weeks: 1 });
+    }
+  } else {
+    next = dt.plus({ [rule.unit + 's']: rule.interval });
+  }
+
+  return hasTime ? next.toFormat("yyyy-MM-dd'T'HH:mm") : next.toISODate()!;
+}
+
+const STATUS_PROPERTIES = ['completion', 'cancelled', 'deferred'];
+
+export function buildRecurringTaskLine(
+  completedTask: ParsedTask,
+  dateProperty: string,
+  startDateProperty: string
+): string | null {
+  const recurrenceValue = getTaskProperty(completedTask, 'recurrence');
+  if (!recurrenceValue) return null;
+
+  const rule = parseRecurrence(recurrenceValue);
+  if (!rule) return null;
+
+  const dueDate = getTaskProperty(completedTask, dateProperty);
+  if (!dueDate) return null;
+
+  const newDueDate = calculateNextDate(dueDate, rule);
+
+  let newTask = cloneTask(completedTask);
+  newTask.status = ' ';
+
+  newTask = setTaskProperty(newTask, dateProperty, newDueDate);
+
+  const startDate = getTaskProperty(completedTask, startDateProperty);
+  if (startDate) {
+    const oldDue = DateTime.fromISO(dueDate);
+    const newDue = DateTime.fromISO(newDueDate);
+    const oldStart = DateTime.fromISO(startDate);
+    if (oldDue.isValid && newDue.isValid && oldStart.isValid) {
+      const delta = newDue.diff(oldDue);
+      const newStart = oldStart.plus(delta);
+      const hasTime = startDate.includes('T');
+      const formatted = hasTime
+        ? newStart.toFormat("yyyy-MM-dd'T'HH:mm")
+        : newStart.toISODate()!;
+      newTask = setTaskProperty(newTask, startDateProperty, formatted);
+    }
+  }
+
+  for (const prop of STATUS_PROPERTIES) {
+    newTask = removeTaskProperty(newTask, prop);
+  }
+
+  return reconstructTask(newTask);
+}
+
+export interface RecurringFrontmatter {
+  frontmatter: Record<string, unknown>;
+  body: string;
+}
+
+export function buildRecurringFrontmatter(
+  frontmatter: Record<string, unknown>,
+  body: string,
+  dateProperty: string,
+  startDateProperty: string
+): RecurringFrontmatter | null {
+  const recurrenceValue = frontmatter.recurrence;
+  if (typeof recurrenceValue !== 'string') return null;
+
+  const rule = parseRecurrence(recurrenceValue);
+  if (!rule) return null;
+
+  const dueDate = frontmatter[dateProperty];
+  if (typeof dueDate !== 'string') return null;
+
+  const newDueDate = calculateNextDate(dueDate, rule);
+
+  const newFm: Record<string, unknown> = { ...frontmatter };
+  newFm.status = ' ';
+  newFm[dateProperty] = newDueDate;
+
+  const startDate = frontmatter[startDateProperty];
+  if (typeof startDate === 'string') {
+    const oldDue = DateTime.fromISO(dueDate);
+    const newDue = DateTime.fromISO(newDueDate);
+    const oldStart = DateTime.fromISO(startDate);
+    if (oldDue.isValid && newDue.isValid && oldStart.isValid) {
+      const delta = newDue.diff(oldDue);
+      const newStart = oldStart.plus(delta);
+      const hasTime = startDate.includes('T');
+      newFm[startDateProperty] = hasTime
+        ? newStart.toFormat("yyyy-MM-dd'T'HH:mm")
+        : newStart.toISODate()!;
+    }
+  }
+
+  for (const prop of STATUS_PROPERTIES) {
+    delete newFm[prop];
+  }
+
+  return { frontmatter: newFm, body };
+}

--- a/src/frontend/TaskClickTooltip.tsx
+++ b/src/frontend/TaskClickTooltip.tsx
@@ -12,6 +12,7 @@ import {
   Plus,
   Trash2,
   AlertCircle,
+  Repeat,
 } from 'lucide-react';
 import { DateTimePickerModal } from './DateTimePickerModal';
 import { StatusPickerDropdown } from './StatusPickerDropdown';
@@ -55,6 +56,9 @@ interface TaskClickTooltipProps {
   ) => void;
   // Delete task callback
   onDeleteTask?: (filePath: string, line?: number) => Promise<boolean>;
+  // Recurrence
+  recurrence?: string;
+  onUpdateRecurrence?: (newPattern: string) => void;
   // New props for task creation mode
   isCreateMode?: boolean;
   selectedDate?: Date;
@@ -87,6 +91,8 @@ export const TaskClickTooltip: React.FC<TaskClickTooltipProps> = ({
   onUpdateText,
   onHoverLink,
   onDeleteTask,
+  recurrence,
+  onUpdateRecurrence,
   // New props with defaults
   isCreateMode = false,
   selectedDate,
@@ -132,6 +138,13 @@ export const TaskClickTooltip: React.FC<TaskClickTooltipProps> = ({
 
   const [isDeleting, setIsDeleting] = useState<boolean>(false);
   const [showDeleteConfirm, setShowDeleteConfirm] = useState<boolean>(false);
+
+  // Recurrence editing state
+  const [isEditingRecurrence, setIsEditingRecurrence] =
+    useState<boolean>(false);
+  const [editedRecurrence, setEditedRecurrence] = useState<string>(
+    recurrence ?? ''
+  );
 
   // Add state for destination selection
   const [selectedDestination, setSelectedDestination] = useState<string>(
@@ -421,6 +434,76 @@ export const TaskClickTooltip: React.FC<TaskClickTooltipProps> = ({
     );
   };
 
+  const handleRecurrenceSave = () => {
+    if (onUpdateRecurrence) {
+      onUpdateRecurrence(editedRecurrence.trim());
+    }
+    setIsEditingRecurrence(false);
+  };
+
+  const formatRecurrenceDisplay = () => {
+    if (!recurrence && !isEditingRecurrence) return null;
+
+    if (isEditingRecurrence) {
+      return (
+        <div className="task-click-tooltip-info-item">
+          <Repeat
+            size={isMobile ? 18 : 16}
+            className="task-click-tooltip-icon-small"
+          />
+          <div className="task-click-tooltip-recurrence-edit">
+            <input
+              type="text"
+              className="task-click-tooltip-recurrence-input"
+              value={editedRecurrence}
+              onChange={e => setEditedRecurrence(e.target.value)}
+              onKeyDown={e => {
+                if (e.key === 'Enter') handleRecurrenceSave();
+                if (e.key === 'Escape') {
+                  setIsEditingRecurrence(false);
+                  setEditedRecurrence(recurrence ?? '');
+                }
+              }}
+              placeholder="e.g. every week"
+              autoFocus
+            />
+            <button
+              className="task-click-tooltip-recurrence-save"
+              onClick={handleRecurrenceSave}
+              title="Save recurrence"
+            >
+              <Check size={isMobile ? 18 : 16} />
+            </button>
+          </div>
+        </div>
+      );
+    }
+
+    return (
+      <div className="task-click-tooltip-info-item">
+        <Repeat
+          size={isMobile ? 18 : 16}
+          className="task-click-tooltip-icon-small"
+        />
+        <span
+          className="task-click-tooltip-info-text"
+          onClick={
+            onUpdateRecurrence
+              ? () => {
+                  setIsEditingRecurrence(true);
+                  setEditedRecurrence(recurrence ?? '');
+                }
+              : undefined
+          }
+          style={onUpdateRecurrence ? { cursor: 'pointer' } : undefined}
+          title={onUpdateRecurrence ? 'Click to edit recurrence' : undefined}
+        >
+          {recurrence}
+        </span>
+      </div>
+    );
+  };
+
   // Delete task handlers
   const handleDeleteClick = () => {
     setShowDeleteConfirm(true);
@@ -641,6 +724,8 @@ export const TaskClickTooltip: React.FC<TaskClickTooltipProps> = ({
 
             {formatDateDisplay()}
 
+            {formatRecurrenceDisplay()}
+
             {formatTagsDisplay()}
 
             {!isCreateMode && (
@@ -803,6 +888,8 @@ export const TaskClickTooltip: React.FC<TaskClickTooltipProps> = ({
           )}
 
           {formatDateDisplay()}
+
+          {formatRecurrenceDisplay()}
 
           {formatTagsDisplay()}
 

--- a/styles.css
+++ b/styles.css
@@ -384,6 +384,15 @@
   text-decoration: line-through;
 }
 
+.tasks-calendar-container .fc-event.tasks-calendar-event-ghost {
+  opacity: 0.4;
+  cursor: default;
+}
+
+.tasks-calendar-container .fc-event.tasks-calendar-event-ghost:hover {
+  filter: none;
+}
+
 /* Task preview popup styles */
 .task-preview-popup {
   position: absolute;
@@ -869,7 +878,35 @@
   transition: color 0.15s ease;
 }
 
-/* Add these styles to your CSS file */
+.task-click-tooltip-recurrence-edit {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  flex: 1;
+}
+
+.task-click-tooltip-recurrence-input {
+  flex: 1;
+  font-size: 0.9em;
+  padding: 2px 6px;
+  border: 1px solid var(--background-modifier-border);
+  border-radius: 4px;
+  background-color: var(--background-primary);
+  color: var(--text-normal);
+  min-width: 0;
+}
+
+.task-click-tooltip-recurrence-save {
+  flex-shrink: 0;
+  background: none;
+  border: none;
+  color: var(--text-accent);
+  cursor: pointer;
+  padding: 2px;
+  display: flex;
+  align-items: center;
+}
+
 .task-click-tooltip-tags-container {
   display: flex;
   flex-wrap: wrap;


### PR DESCRIPTION
Add recurring task support for both inline and frontmatter tasks. When a task with a `recurrence` property (e.g. `[recurrence:: every week]`) is completed, a new task is automatically created with the next due date.

Backend:
- Add `recurrence.ts` with pattern parsing, next-date calculation, and builders for both inline tasks (`buildRecurringTaskLine`) and frontmatter tasks (`buildRecurringFrontmatter`)
- Add `processFileLineWithInsert()` to `file-operations.ts` for atomically updating a line and inserting a new one
- Refactor `updateTaskStatus()` to accept date properties and return `UpdateStatusResult` indicating whether a recurring task was created
- For frontmatter recurring tasks, keep the completed note as-is and create the next occurrence as a new note with the due date in its title
- Add `updateTaskRecurrence()` for editing the recurrence property from the tooltip

Frontend:
- Add `recurrence` and `isGhost` to `ExtendedProps` and generate ghost events (faded next-occurrence preview) for incomplete recurring tasks
- Add recurrence row with inline editing to the task tooltip between date and tags rows
- Ghost events are non-draggable and omit `onUpdateDates`
- Skip redundant notifications when recurrence or status values are unchanged

Update CHANGELOG and README with recurring task
documentation.

---

- Closes #3 