### PR TITLE
feat: add external calendar source support (ICS files)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,15 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- External calendar source support: overlay events from local ICS files on the
+  calendar. Configure per-calendar in the settings modal with file path, color,
+  and opacity. Supports standard ICS `VEVENT` entries (all-day and timed events,
+  UTC and timezone-aware datetimes). External events are read-only and visually
+  distinguished by configurable color and opacity. The calendar auto-refreshes
+  when a configured ICS file changes in the vault.
+
 ### Changed
 
 - Addressed Obsidian plugin guideline compliance issues flagged by

--- a/README.md
+++ b/README.md
@@ -58,6 +58,10 @@ That's it. You are free to write your tasks wherever you want.
   - Click any date inline field to open a date picker (works in both live
     preview and reading view)
 
+- **External calendar sources**: Overlay events from local ICS files onto the
+  calendar. Configure file path, color, and opacity per source. Events
+  auto-refresh when the ICS file changes in the vault.
+
 - **Customization options**: Configure calendar settings such as view type,
   first day of the week, and date properties. Manage multiple calendars with
   individual settings.
@@ -190,6 +194,16 @@ You can install Tasks Calendar either via
   completed task. For file property tasks, the completed file is renamed to
   `<name> (completed <date>).md` and a new file with the original name is
   created with the updated due date.
+
+- **External calendar sources** You can overlay events from local ICS files onto
+  the calendar. Open a calendar's settings modal and scroll to the "External
+  calendar sources" section. Add an `.ics` file path from your vault, choose a
+  color and opacity, and the events will appear as read-only overlays. The
+  calendar automatically refreshes when a configured ICS file changes.
+
+  The ICS parser supports standard `VEVENT` entries including all-day events,
+  timed events with UTC or timezone-aware datetimes, and RFC 5545 line
+  unfolding.
 
 ## Related plugins
 

--- a/src/TasksCalendarItemView.ts
+++ b/src/TasksCalendarItemView.ts
@@ -38,6 +38,7 @@ import { calculateOptimalPosition } from './backend/position';
 import { createTask } from './backend/create';
 import { deleteTask } from './backend/delete';
 import handleError from './backend/error-handling';
+import { parseIcsEvents } from './backend/ics';
 import { createLogger } from './logging';
 
 export class TasksCalendarItemView extends ItemView {
@@ -153,6 +154,12 @@ export class TasksCalendarItemView extends ItemView {
         hour: '2-digit',
         minute: '2-digit',
         hour12: false,
+      },
+      eventDidMount: info => {
+        const opacity = info.event.extendedProps.opacity as number | undefined;
+        if (opacity !== undefined) {
+          info.el.style.opacity = String(opacity);
+        }
       },
       eventDrop: info => {
         if (info.event && info.oldEvent)
@@ -327,6 +334,17 @@ export class TasksCalendarItemView extends ItemView {
             this.calendar.updateSize();
           }
         }, 100);
+      })
+    );
+
+    this.registerEvent(
+      this.app.vault.on('modify', file => {
+        if (
+          this.settings.externalSources.some(s => s.path === file.path) &&
+          this.calendar
+        ) {
+          this.calendar.refetchEvents();
+        }
       })
     );
   }
@@ -832,22 +850,58 @@ export class TasksCalendarItemView extends ItemView {
     successCallback: (events: EventInput[]) => void,
     failureCallback: (error: Error) => void
   ) {
-    const dataviewApi = this.plugin.dataviewApi;
-    if (!dataviewApi) {
-      this.logger.warn('Dataview plugin not available');
-      new Notice(
-        'Dataview plugin is not available. Tasks calendar may not work correctly.'
+    void (async () => {
+      const dataviewApi = this.plugin.dataviewApi;
+      if (!dataviewApi) {
+        this.logger.warn('Dataview plugin not available');
+        new Notice(
+          'Dataview plugin is not available. Tasks calendar may not work correctly.'
+        );
+        failureCallback(new Error('Dataview plugin is not available'));
+        return;
+      }
+      let taskEvents: EventInput[];
+      try {
+        taskEvents = getTasksAsEvents(dataviewApi, this.settings);
+      } catch (error) {
+        this.logger.warn(`Failed to fetch task events: ${error}`);
+        failureCallback(
+          error instanceof Error ? error : new Error(String(error))
+        );
+        return;
+      }
+      const externalEvents = await this.fetchExternalEvents();
+      this.logger.log(
+        `Fetched ${taskEvents.length} task events, ${externalEvents.length} external events`
       );
-      return failureCallback(new Error('Dataview plugin is not available'));
+      successCallback([...taskEvents, ...externalEvents]);
+    })();
+  }
+
+  private async fetchExternalEvents(): Promise<EventInput[]> {
+    const sources = this.settings.externalSources;
+    if (sources.length === 0) return [];
+
+    const results: EventInput[] = [];
+    for (const source of sources) {
+      const file = this.app.vault.getAbstractFileByPath(source.path);
+      if (!(file instanceof TFile)) {
+        this.logger.warn(`External source file not found: ${source.path}`);
+        continue;
+      }
+      let content: string;
+      try {
+        content = await this.app.vault.read(file);
+      } catch (error) {
+        this.logger.warn(
+          `Failed to read external source ${source.path}: ${error}`
+        );
+        continue;
+      }
+      const events = parseIcsEvents(content, source);
+      results.push(...events);
     }
-    try {
-      const events = getTasksAsEvents(dataviewApi, this.settings);
-      this.logger.log(`Fetched ${events.length} events`);
-      successCallback(events);
-    } catch (error) {
-      this.logger.warn(`Failed to fetch events: ${error}`);
-      failureCallback(error);
-    }
+    return results;
   }
 
   private setupResizeObserver(calendarEl: HTMLElement) {

--- a/src/TasksCalendarSettings.ts
+++ b/src/TasksCalendarSettings.ts
@@ -20,6 +20,12 @@ interface EventPropsMap {
   [key: string]: EventProps;
 }
 
+export interface ExternalSource {
+  path: string;
+  color: string;
+  opacity: number;
+}
+
 /**
  * Represents the minimal calendar settings stored in data.json
  * All properties except id and name are optional
@@ -37,6 +43,7 @@ export interface UserCalendarSettings {
   includedTags?: string[]; // included tags, empty array means including every task
   eventPropsMap?: EventPropsMap; // event info map
   newTaskFilePaths?: string[]; // New setting for multiple task creation file paths
+  externalSources?: ExternalSource[]; // external calendar sources (e.g. ICS files)
 }
 
 /**
@@ -56,6 +63,7 @@ export interface CalendarSettings {
   includedTags: string[]; // included tags, empty array means including every task
   eventPropsMap: EventPropsMap; // event info map
   newTaskFilePaths: string[]; // New setting for multiple task creation file paths
+  externalSources: ExternalSource[]; // external calendar sources (e.g. ICS files)
 }
 
 export type LogLevel = 'error' | 'warn' | 'log';
@@ -119,6 +127,7 @@ export const DEFAULT_CALENDAR_SETTINGS: CalendarSettings = {
     // 'x': { textColor: 'var(--text-faint)', backgroundColor: 'var(--background-secondary)', display: 'block', priority: -1 },
   },
   newTaskFilePaths: ['Tasks.md'], // Default file path for new tasks
+  externalSources: [],
 };
 
 export const DEFAULT_PLUGIN_SETTINGS: PluginSettings = {
@@ -192,6 +201,11 @@ export function toUserCalendarSettings(
     JSON.stringify(DEFAULT_CALENDAR_SETTINGS.eventPropsMap)
   )
     userSettings.eventPropsMap = settings.eventPropsMap;
+  if (
+    JSON.stringify(settings.externalSources) !==
+    JSON.stringify(DEFAULT_CALENDAR_SETTINGS.externalSources)
+  )
+    userSettings.externalSources = settings.externalSources;
 
   return userSettings;
 }

--- a/src/backend/ics.ts
+++ b/src/backend/ics.ts
@@ -1,0 +1,153 @@
+import { EventInput } from '@fullcalendar/core';
+import { DateTime } from 'luxon';
+import { ExternalSource } from '../TasksCalendarSettings';
+import { createLogger } from '../logging';
+
+const logger = createLogger('IcsParser');
+
+export function parseIcsEvents(
+  content: string,
+  source: ExternalSource
+): EventInput[] {
+  const lines = unfoldLines(content);
+  const events: EventInput[] = [];
+  let inEvent = false;
+  let eventProps: Map<string, string> = new Map();
+
+  for (const line of lines) {
+    if (line === 'BEGIN:VEVENT') {
+      inEvent = true;
+      eventProps = new Map();
+      continue;
+    }
+    if (line === 'END:VEVENT') {
+      inEvent = false;
+      try {
+        const event = buildEvent(eventProps, source);
+        if (event) events.push(event);
+      } catch (error) {
+        logger.warn(`Skipping malformed VEVENT: ${error}`);
+      }
+      continue;
+    }
+    if (inEvent) {
+      const colonIdx = line.indexOf(':');
+      if (colonIdx === -1) continue;
+      const key = line.substring(0, colonIdx);
+      const value = line.substring(colonIdx + 1);
+      eventProps.set(key, value);
+    }
+  }
+
+  return events;
+}
+
+function unfoldLines(raw: string): string[] {
+  return raw
+    .replace(/\r\n/g, '\n')
+    .replace(/\r/g, '\n')
+    .replace(/\n[ \t]/g, '')
+    .split('\n')
+    .filter(line => line.length > 0);
+}
+
+function unescapeIcsText(s: string): string {
+  return s
+    .replace(/\\n/gi, '\n')
+    .replace(/\\,/g, ',')
+    .replace(/\\;/g, ';')
+    .replace(/\\\\/g, '\\');
+}
+
+interface IcsDateResult {
+  date: Date;
+  allDay: boolean;
+}
+
+function parseIcsDate(key: string, value: string): IcsDateResult | null {
+  const params = key.split(';');
+  const isDateOnly = params.some(p => p === 'VALUE=DATE');
+  const tzidParam = params.find(p => p.startsWith('TZID='));
+
+  if (isDateOnly) {
+    const dt = DateTime.fromFormat(value, 'yyyyMMdd');
+    if (!dt.isValid) return null;
+    return { date: dt.toJSDate(), allDay: true };
+  }
+
+  if (value.endsWith('Z')) {
+    const dt = DateTime.fromFormat(value.slice(0, -1), "yyyyMMdd'T'HHmmss", {
+      zone: 'UTC',
+    });
+    if (!dt.isValid) return null;
+    return { date: dt.toJSDate(), allDay: false };
+  }
+
+  if (tzidParam) {
+    const tzid = tzidParam.substring('TZID='.length);
+    const dt = DateTime.fromFormat(value, "yyyyMMdd'T'HHmmss", { zone: tzid });
+    if (!dt.isValid) return null;
+    return { date: dt.toJSDate(), allDay: false };
+  }
+
+  const dt = DateTime.fromFormat(value, "yyyyMMdd'T'HHmmss");
+  if (!dt.isValid) return null;
+  return { date: dt.toJSDate(), allDay: false };
+}
+
+function findDateProp(
+  props: Map<string, string>,
+  prefix: string
+): { key: string; value: string } | null {
+  for (const [key, value] of props) {
+    if (key === prefix || key.startsWith(prefix + ';')) {
+      return { key, value };
+    }
+  }
+  return null;
+}
+
+function buildEvent(
+  props: Map<string, string>,
+  source: ExternalSource
+): EventInput | null {
+  const startEntry = findDateProp(props, 'DTSTART');
+  if (!startEntry) return null;
+
+  const startResult = parseIcsDate(startEntry.key, startEntry.value);
+  if (!startResult) return null;
+
+  let end: Date | undefined;
+  let allDay = startResult.allDay;
+  const endEntry = findDateProp(props, 'DTEND');
+  if (endEntry) {
+    const endResult = parseIcsDate(endEntry.key, endEntry.value);
+    if (endResult) {
+      end = endResult.date;
+      allDay = allDay && endResult.allDay;
+    }
+  }
+
+  const summary = props.get('SUMMARY');
+  const title = summary ? unescapeIcsText(summary) : source.path;
+
+  const description = props.get('DESCRIPTION');
+
+  return {
+    title,
+    start: startResult.date,
+    end,
+    allDay,
+    backgroundColor: source.color,
+    borderColor: source.color,
+    textColor: 'var(--text-on-accent)',
+    classNames: ['tasks-calendar-event-external'],
+    editable: false,
+    extendedProps: {
+      isExternal: true,
+      opacity: source.opacity,
+      ...(description && { description: unescapeIcsText(description) }),
+      sourcePath: source.path,
+    },
+  };
+}

--- a/src/frontend/CalendarSettingsModal.ts
+++ b/src/frontend/CalendarSettingsModal.ts
@@ -2,6 +2,7 @@ import { App, Modal, Setting } from 'obsidian';
 import {
   CalendarSettings,
   DEFAULT_CALENDAR_SETTINGS,
+  ExternalSource,
 } from '../TasksCalendarSettings';
 import { normalizeTag } from '../backend/tag';
 import { ConfirmModal } from './ConfirmModal';
@@ -47,6 +48,7 @@ export class CalendarSettingsModal extends Modal {
     contentEl.empty();
     this.buildBasicSection(contentEl);
     this.buildFilterSection(contentEl);
+    this.buildExternalSourcesSection(contentEl);
     this.buildDangerSection(contentEl);
   }
 
@@ -201,6 +203,121 @@ export class CalendarSettingsModal extends Modal {
             this.buildContent();
           })
       );
+  }
+
+  private buildExternalSourcesSection(el: HTMLElement): void {
+    const DEFAULT_COLOR = '#3788d8';
+    const DEFAULT_OPACITY = 1;
+
+    new Setting(el)
+      .setName('External calendar sources')
+      .setDesc('ICS files from the vault to overlay on the calendar.')
+      .setHeading();
+
+    const sources = this.settings.externalSources;
+
+    for (const source of sources) {
+      const sourceSetting = new Setting(el);
+
+      const swatch = sourceSetting.nameEl.createSpan({
+        cls: 'tasks-calendar-external-source-swatch',
+      });
+      swatch.style.backgroundColor = source.color;
+      swatch.style.opacity = String(source.opacity);
+      sourceSetting.nameEl.appendText(source.path);
+
+      const colorInput = sourceSetting.controlEl.createEl('input', {
+        type: 'color',
+        value: source.color,
+      });
+      colorInput.addClass('tasks-calendar-external-source-color-input');
+      colorInput.addEventListener('input', () => {
+        this.updateExternalSource(source.path, { color: colorInput.value });
+      });
+
+      sourceSetting.addSlider(slider =>
+        slider
+          .setLimits(0.1, 1.0, 0.1)
+          .setValue(source.opacity)
+          .setDynamicTooltip()
+          .onChange(value => {
+            this.updateExternalSource(source.path, { opacity: value });
+          })
+      );
+
+      sourceSetting.addExtraButton(btn =>
+        btn
+          .setIcon('x')
+          .setTooltip('Remove')
+          .onClick(() => {
+            this.update(
+              'externalSources',
+              sources.filter(s => s.path !== source.path)
+            );
+            this.buildContent();
+          })
+      );
+    }
+
+    let newPath = '';
+    let newColor = DEFAULT_COLOR;
+
+    const addSource = () => {
+      const trimmed = newPath.trim();
+      if (trimmed && !sources.some(s => s.path === trimmed)) {
+        const newSource: ExternalSource = {
+          path: trimmed,
+          color: newColor,
+          opacity: DEFAULT_OPACITY,
+        };
+        this.update('externalSources', [...sources, newSource]);
+        this.buildContent();
+      }
+    };
+
+    const setting = new Setting(el);
+    setting
+      .addSearch(search => {
+        search.setPlaceholder('Add .ics file path...').onChange(value => {
+          newPath = value;
+        });
+        search.inputEl.addEventListener('keydown', (e: KeyboardEvent) => {
+          if (e.key === 'Enter') {
+            e.preventDefault();
+            addSource();
+          }
+        });
+        new PathSuggest(
+          this.app,
+          search.inputEl,
+          value => {
+            newPath = value;
+            addSource();
+          },
+          p => p.endsWith('.ics')
+        );
+      })
+      .addButton(btn => btn.setButtonText('Add').onClick(addSource));
+
+    const colorInput = setting.controlEl.createEl('input', {
+      type: 'color',
+      value: DEFAULT_COLOR,
+    });
+    colorInput.addClass('tasks-calendar-external-source-color-input');
+    colorInput.addEventListener('input', () => {
+      newColor = colorInput.value;
+    });
+    setting.controlEl.insertBefore(colorInput, setting.controlEl.firstChild);
+  }
+
+  private updateExternalSource(
+    path: string,
+    changes: Partial<Omit<ExternalSource, 'path'>>
+  ): void {
+    const sources = this.settings.externalSources.map(s =>
+      s.path === path ? { ...s, ...changes } : s
+    );
+    this.update('externalSources', sources);
   }
 
   private buildFilterSection(el: HTMLElement): void {

--- a/src/frontend/PathSuggest.ts
+++ b/src/frontend/PathSuggest.ts
@@ -2,14 +2,17 @@ import { AbstractInputSuggest, App, TFolder } from 'obsidian';
 
 export class PathSuggest extends AbstractInputSuggest<string> {
   private onSelectCallback: (value: string) => void;
+  private filter?: (path: string) => boolean;
 
   constructor(
     app: App,
     inputEl: HTMLInputElement,
-    onSelect: (value: string) => void
+    onSelect: (value: string) => void,
+    filter?: (path: string) => boolean
   ) {
     super(app, inputEl);
     this.onSelectCallback = onSelect;
+    this.filter = filter;
   }
 
   getSuggestions(query: string): string[] {
@@ -18,6 +21,7 @@ export class PathSuggest extends AbstractInputSuggest<string> {
       .getAllLoadedFiles()
       .map(f => (f instanceof TFolder ? f.path + '/' : f.path))
       .filter(p => p.toLowerCase().includes(lower))
+      .filter(p => !this.filter || this.filter(p))
       .slice(0, 50);
   }
 

--- a/styles.css
+++ b/styles.css
@@ -400,6 +400,29 @@
   filter: none;
 }
 
+.tasks-calendar-container .fc-event.tasks-calendar-event-external {
+  cursor: default;
+  pointer-events: none;
+}
+
+.tasks-calendar-external-source-swatch {
+  display: inline-block;
+  width: 0.75em;
+  height: 0.75em;
+  border-radius: 50%;
+  margin-right: 0.3em;
+  vertical-align: middle;
+  flex-shrink: 0;
+}
+
+.tasks-calendar-external-source-color-input {
+  width: 2em;
+  height: 2em;
+  padding: 0;
+  border: none;
+  cursor: pointer;
+}
+
 .workspace-tab-header[data-type='tasks-calendar-view']
   .workspace-tab-header-inner-icon {
   opacity: 0.9;


### PR DESCRIPTION
Add the ability to overlay events from local ICS files on the calendar. Users can configure external sources per-calendar in the settings modal with file path, color, and opacity.

The ICS parser handles standard `VEVENT` entries including all-day and timed events, UTC and timezone-aware datetimes, and RFC 5545 line unfolding. External events are read-only and non-interactive. The calendar auto-refreshes when a configured ICS file changes in the vault.